### PR TITLE
Apply real code patch for auto-hw-decoder

### DIFF
--- a/src/auto_hw_decoder.rs
+++ b/src/auto_hw_decoder.rs
@@ -1,1 +1,9 @@
-// Changes for auto-hw-decoder
+// Auto-selects NVDEC decoder based on codec
+pub fn auto_select_decoder(codec: &str) -> Option<&'static str> {
+    match codec {
+        "h264" => Some("h264_cuvid"),
+        "hevc" => Some("hevc_cuvid"),
+        "vp9" => Some("vp9_cuvid"),
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add function to automatically select NVDEC decoder for supported codecs (h264, hevc, vp9)